### PR TITLE
Historique conversations

### DIFF
--- a/app/api/simulation/[id]/end/route.ts
+++ b/app/api/simulation/[id]/end/route.ts
@@ -331,6 +331,59 @@ Fournissez un feedback structuré avec:
         console.log("✅ Feedback linked successfully");
       }
 
+      // Generate summary for inter-conversation history
+      console.log("📝 Generating conversation summary...");
+      try {
+        const summaryPrompt = `Tu es un assistant qui résume des conversations commerciales de façon concise.
+
+Voici une conversation entre un commercial et un prospect.
+
+**CONTEXTE:**
+- Prospect: ${conversation.agents?.name} (${conversation.agents?.job_title})
+- Produit: ${conversation.products?.name}
+- Type d'appel: ${conversation.call_type}
+- Durée: ${finalDuration} secondes
+
+**TRANSCRIPT:**
+${transcript
+  .map(
+    (msg: any, i: number) =>
+      `${i + 1}. ${msg.role === "user" || msg.source === "user" ? "Commercial" : "Prospect"}: ${msg.content || msg.message || msg.text}`
+  )
+  .join("\n")}
+
+Génère un résumé factuel en 3-5 phrases maximum (150 mots max) qui capture :
+- Ce qui a été proposé par le commercial
+- Les réactions et objections du prospect
+- Le résultat de l'appel (accord, refus, suite prévue, pas de conclusion)
+
+Ce résumé sera utilisé pour contextualiser les prochains appels avec ce prospect. Réponds uniquement avec le résumé, sans introduction ni titre.`;
+
+        const summaryCommand = new ConverseCommand({
+          modelId: "eu.anthropic.claude-3-7-sonnet-20250219-v1:0",
+          messages: [{ role: "user", content: [{ type: "text", text: summaryPrompt }] }] as any,
+          inferenceConfig: { maxTokens: 300, temperature: 0.1 },
+        });
+
+        const summaryResponse = await client.send(summaryCommand);
+        let summaryText = "";
+        if (summaryResponse.output?.message?.content) {
+          for (const block of summaryResponse.output.message.content) {
+            if ("text" in block) { summaryText = block.text || ""; break; }
+          }
+        }
+
+        if (summaryText) {
+          await supabase
+            .from("conversations")
+            .update({ summary: summaryText.trim() })
+            .eq("id", conversationId);
+          console.log("✅ Summary generated and saved");
+        }
+      } catch (summaryError) {
+        console.warn("⚠️ Failed to generate summary (non-blocking):", summaryError);
+      }
+
       console.log("🎉 Conversation analysis completed successfully!");
       return NextResponse.json({
         feedback,

--- a/app/api/simulation/start/route.ts
+++ b/app/api/simulation/start/route.ts
@@ -251,6 +251,38 @@ export async function POST(request: NextRequest) {
     const agent = conversationDetails.agents;
     const product = conversationDetails.products;
 
+    // Build history block
+    let historyBlock = "";
+    if (conversationDetails.history_conversation_ids?.length > 0) {
+      const { data: historicConvs } = await supabase
+        .from("conversations")
+        .select("id, call_type, created_at, summary")
+        .in("id", conversationDetails.history_conversation_ids)
+        .order("created_at", { ascending: true });
+
+      if (historicConvs && historicConvs.length > 0) {
+        const callTypeLabels: Record<string, string> = {
+          cold_call: "Cold call",
+          discovery_meeting: "Réunion de découverte",
+          product_demo: "Démo produit",
+          closing_call: "Closing",
+          follow_up_call: "Relance",
+        };
+        historyBlock = `
+HISTORIQUE DE VOS ÉCHANGES PRÉCÉDENTS (tu te souviens de tout ça comme si c'était réel) :
+${historicConvs.map(c => {
+  const date = new Date(c.created_at).toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" });
+  return `[${callTypeLabels[c.call_type] || c.call_type} — ${date}]\n${c.summary}`;
+}).join("\n\n")}
+`;
+      }
+    } else if (conversationDetails.history_context) {
+      historyBlock = `
+HISTORIQUE DE LA RELATION (contexte fourni par le commercial) :
+${conversationDetails.history_context}
+`;
+    }
+
     if (!agent) {
       console.error("❌ No agent found in conversation");
       return NextResponse.json({ error: "Agent introuvable" }, { status: 400 });
@@ -353,7 +385,7 @@ ${callTypeBehavior}
 ${conversationDetails.goal ? `
 CONTEXTE PERSONNALISÉ (TRÈS IMPORTANT - tu dois intégrer ces informations dans ton jeu de rôle):
 ${conversationDetails.goal}
-` : ""}
+` : ""}${historyBlock}
 
 INSTRUCTIONS:
 1. TU ES PASSIF - C'est l'autre personne qui t'appelle, tu réponds seulement à ses questions.

--- a/components/simulation/simulation-stepper.tsx
+++ b/components/simulation/simulation-stepper.tsx
@@ -26,12 +26,25 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Skeleton } from "../ui/skeleton";
 
+type HistoryMode = "zero" | "manual" | "previous";
+
+interface PreviousConversation {
+  id: string;
+  call_type: string;
+  created_at: string;
+  summary: string;
+  feedback?: { note: number } | null;
+}
+
 interface SimulationConfig {
   agent: Agent | null;
   product: Product | null;
   callType: CallType | null;
   goal: string;
   maxDuration: number;
+  historyMode: HistoryMode;
+  historyContext: string;
+  historyUntilId: string | null;
   context: {
     secteur: string;
     company: string;
@@ -90,12 +103,16 @@ export function SimulationStepper() {
   const [products, setProducts] = useState<Product[]>([]);
   const [loading, setLoading] = useState(true);
   const [startingSimulation, setStartingSimulation] = useState(false);
+  const [previousConversations, setPreviousConversations] = useState<PreviousConversation[]>([]);
   const [config, setConfig] = useState<SimulationConfig>({
     agent: null,
     product: null,
     callType: null,
     goal: "",
     maxDuration: 2700,
+    historyMode: "zero",
+    historyContext: "",
+    historyUntilId: null,
     context: {
       secteur: "",
       company: "",
@@ -116,6 +133,35 @@ export function SimulationStepper() {
       loadSavedConfig(config.agent.id);
     }
   }, [config.agent?.id]);
+
+  // Load previous conversations when agent + product are selected
+  useEffect(() => {
+    if (config.agent?.id && config.product?.id) {
+      loadPreviousConversations(config.agent.id, config.product.id);
+    } else {
+      setPreviousConversations([]);
+    }
+  }, [config.agent?.id, config.product?.id]);
+
+  const loadPreviousConversations = async (agentId: string, productId: string) => {
+    try {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) return;
+
+      const { data } = await supabase
+        .from("conversations")
+        .select("id, call_type, created_at, summary, feedback:feedback_id(note)")
+        .eq("user_id", user.id)
+        .eq("agent_id", agentId)
+        .eq("product_id", productId)
+        .not("summary", "is", null)
+        .order("created_at", { ascending: true });
+
+      setPreviousConversations((data as any) || []);
+    } catch (error) {
+      console.error("Error loading previous conversations:", error);
+    }
+  };
 
   const loadSavedConfig = (agentId: string) => {
     try {
@@ -270,6 +316,14 @@ export function SimulationStepper() {
         }
       });
 
+      // Build history fields
+      const historyConversationIds =
+        config.historyMode === "previous" && config.historyUntilId
+          ? previousConversations
+              .slice(0, previousConversations.findIndex(c => c.id === config.historyUntilId) + 1)
+              .map(c => c.id)
+          : null;
+
       // Create conversation record
       const { data: conversation, error } = await supabase
         .from("conversations")
@@ -281,6 +335,8 @@ export function SimulationStepper() {
           context: config.context,
           call_type: config.callType,
           max_duration_seconds: config.maxDuration,
+          history_context: config.historyMode === "manual" ? config.historyContext : null,
+          history_conversation_ids: historyConversationIds,
         })
         .select()
         .single();
@@ -650,6 +706,7 @@ export function SimulationStepper() {
                           ))}
                         </select>
                       </div>
+
                     </div>
                     <div className="space-y-4">
                       <h3 className="font-semibold">Contexte personnalis&eacute;</h3>
@@ -678,6 +735,61 @@ export function SimulationStepper() {
                           className="shadow-soft resize-none mt-3 placeholder:text-foreground/20 min-h-[10rem]"
                         />
                       </div>
+                    </div>
+                  </div>
+
+                  {/* Historique de la relation */}
+                  <div className="space-y-3">
+                    <Label className="font-semibold text-base">Historique de la relation</Label>
+                    <div className="space-y-2 mt-3">
+                      <label className="flex items-center gap-2 cursor-pointer">
+                        <input type="radio" name="historyMode" value="zero" checked={config.historyMode === "zero"} onChange={() => setConfig({ ...config, historyMode: "zero", historyContext: "", historyUntilId: null })} className="accent-[#9516C7]" />
+                        <span className="text-sm">Repartir de zéro</span>
+                      </label>
+                      <label className="flex items-center gap-2 cursor-pointer">
+                        <input type="radio" name="historyMode" value="manual" checked={config.historyMode === "manual"} onChange={() => setConfig({ ...config, historyMode: "manual", historyUntilId: null })} className="accent-[#9516C7]" />
+                        <span className="text-sm">Saisir manuellement</span>
+                      </label>
+                      {config.historyMode === "manual" && (
+                        <Textarea
+                          placeholder="Décrivez le contexte de vos échanges précédents avec ce prospect..."
+                          value={config.historyContext}
+                          onChange={(e) => setConfig({ ...config, historyContext: e.target.value })}
+                          rows={3}
+                          className="shadow-soft resize-none placeholder:text-foreground/20 ml-6"
+                        />
+                      )}
+                      <label className={`flex items-center gap-2 ${previousConversations.length === 0 ? "opacity-40 cursor-not-allowed" : "cursor-pointer"}`}>
+                        <input type="radio" name="historyMode" value="previous" checked={config.historyMode === "previous"} disabled={previousConversations.length === 0} onChange={() => setConfig({ ...config, historyMode: "previous", historyContext: "" })} className="accent-[#9516C7]" />
+                        <span className="text-sm">
+                          Reprendre l&apos;historique des appels
+                          {previousConversations.length === 0 && (
+                            <span className="text-xs text-muted-foreground ml-2">— Aucun appel précédent pour ce prospect + produit</span>
+                          )}
+                        </span>
+                      </label>
+                      {config.historyMode === "previous" && previousConversations.length > 0 && (
+                        <div className="ml-6">
+                          <Label className="text-xs text-muted-foreground mb-2 block">Reprendre l&apos;historique jusqu&apos;à :</Label>
+                          <select
+                            className="w-full p-2 border rounded-md shadow-soft text-sm"
+                            value={config.historyUntilId ?? ""}
+                            onChange={(e) => setConfig({ ...config, historyUntilId: e.target.value || null })}
+                          >
+                            <option value="">-- Choisir un appel --</option>
+                            {previousConversations.map((conv, index) => {
+                              const callTypeLabels: Record<string, string> = { cold_call: "Cold call", discovery_meeting: "Découverte", product_demo: "Démo produit", closing_call: "Closing", follow_up_call: "Relance" };
+                              const date = new Date(conv.created_at).toLocaleDateString("fr-FR", { day: "numeric", month: "long" });
+                              const label = `${callTypeLabels[conv.call_type] || conv.call_type} — ${date}${(conv.feedback as any)?.note ? ` — ${(conv.feedback as any).note}/100` : ""}`;
+                              return (
+                                <option key={conv.id} value={conv.id}>
+                                  {label} {index > 0 ? `(inclut ${index + 1} appels)` : ""}
+                                </option>
+                              );
+                            })}
+                          </select>
+                        </div>
+                      )}
                     </div>
                   </div>
 

--- a/components/simulation/simulation-stepper.tsx
+++ b/components/simulation/simulation-stepper.tsx
@@ -651,42 +651,6 @@ export function SimulationStepper() {
                         />
                       </div>
                       <div>
-                        <Label htmlFor="historique">
-                          Historique de la relation
-                        </Label>
-                        <select
-                          className="w-full p-2 border rounded-md shadow-soft mt-3"
-                          value={config.context.historique_relation}
-                          onChange={(e) => {
-                            const newConfig = {
-                              ...config,
-                              context: {
-                                ...config.context,
-                                historique_relation: e.target
-                                  .value as HistoriqueRelation,
-                              },
-                            };
-                            setConfig(newConfig);
-                            // Save to localStorage
-                            if (config.agent?.id) {
-                              saveConfig(config.agent.id, {
-                                context: {
-                                  ...config.context,
-                                  historique_relation: e.target
-                                    .value as HistoriqueRelation,
-                                },
-                              });
-                            }
-                          }}
-                        >
-                          {historiqueOptions.map((option) => (
-                            <option key={option} value={option}>
-                              {option}
-                            </option>
-                          ))}
-                        </select>
-                      </div>
-                      <div>
                         <Label htmlFor="duration">Durée de l'appel</Label>
                         <select
                           id="duration"
@@ -702,6 +666,43 @@ export function SimulationStepper() {
                           {durationOptions.map((opt) => (
                             <option key={opt.value} value={opt.value}>
                               {opt.label}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+                      <div>
+                        <Label htmlFor="historique">
+                          Historique de la relation
+                        </Label>
+                        <select
+                          className="w-full p-2 border rounded-md shadow-soft mt-3"
+                          value={config.context.historique_relation}
+                          onChange={(e) => {
+                            const newHistorique = e.target.value as HistoriqueRelation;
+                            const newConfig = {
+                              ...config,
+                              context: {
+                                ...config.context,
+                                historique_relation: newHistorique,
+                              },
+                              // Quand on passe à un appel non-premier contact, forcer manual si on était sur zero
+                              historyMode: (newHistorique !== "Premier contact" && config.historyMode === "zero") ? "manual" as HistoryMode : config.historyMode,
+                            };
+                            setConfig(newConfig);
+                            // Save to localStorage
+                            if (config.agent?.id) {
+                              saveConfig(config.agent.id, {
+                                context: {
+                                  ...config.context,
+                                  historique_relation: newHistorique,
+                                },
+                              });
+                            }
+                          }}
+                        >
+                          {historiqueOptions.map((option) => (
+                            <option key={option} value={option}>
+                              {option}
                             </option>
                           ))}
                         </select>
@@ -739,13 +740,9 @@ export function SimulationStepper() {
                   </div>
 
                   {/* Historique de la relation */}
-                  <div className="space-y-3 pt-2">
+                  {config.context.historique_relation !== "Premier contact" && <div className="space-y-3 pt-2">
                     <Label className="font-semibold text-base">Historique de la relation</Label>
                     <div className="space-y-3 mt-1">
-                      <label className="flex items-center gap-3 cursor-pointer py-1">
-                        <input type="radio" name="historyMode" value="zero" checked={config.historyMode === "zero"} onChange={() => setConfig({ ...config, historyMode: "zero", historyContext: "", historyUntilId: null })} className="accent-[#9516C7] w-4 h-4 shrink-0" />
-                        <span className="text-sm">Repartir de zéro</span>
-                      </label>
                       <label className="flex items-center gap-3 cursor-pointer py-1">
                         <input type="radio" name="historyMode" value="manual" checked={config.historyMode === "manual"} onChange={() => setConfig({ ...config, historyMode: "manual", historyUntilId: null })} className="accent-[#9516C7] w-4 h-4 shrink-0" />
                         <span className="text-sm">Saisir manuellement</span>
@@ -791,7 +788,7 @@ export function SimulationStepper() {
                         </div>
                       )}
                     </div>
-                  </div>
+                  </div>}
 
                   {/* Preview */}
                   <div className="border-t pt-6">

--- a/components/simulation/simulation-stepper.tsx
+++ b/components/simulation/simulation-stepper.tsx
@@ -413,7 +413,7 @@ export function SimulationStepper() {
       </div>
 
       {/* Step Content */}
-      <Card className="min-h-[500px] shadow-soft">
+      <Card className="min-h-[500px] shadow-soft overflow-hidden">
         <CardHeader>
           <CardTitle>
             {currentStep === 1 && "Choisissez votre prospect"}
@@ -590,7 +590,7 @@ export function SimulationStepper() {
 
               {/* Step 4: Context and Goal */}
               {currentStep === 4 && (
-                <div className="space-y-6">
+                <div className="space-y-6 w-full max-w-full">
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                     <div className="space-y-4">
                       <h3 className="font-semibold">Contexte de l'appel</h3>
@@ -739,15 +739,15 @@ export function SimulationStepper() {
                   </div>
 
                   {/* Historique de la relation */}
-                  <div className="space-y-3">
+                  <div className="space-y-3 pt-2">
                     <Label className="font-semibold text-base">Historique de la relation</Label>
-                    <div className="space-y-2 mt-3">
-                      <label className="flex items-center gap-2 cursor-pointer">
-                        <input type="radio" name="historyMode" value="zero" checked={config.historyMode === "zero"} onChange={() => setConfig({ ...config, historyMode: "zero", historyContext: "", historyUntilId: null })} className="accent-[#9516C7]" />
+                    <div className="space-y-3 mt-1">
+                      <label className="flex items-center gap-3 cursor-pointer py-1">
+                        <input type="radio" name="historyMode" value="zero" checked={config.historyMode === "zero"} onChange={() => setConfig({ ...config, historyMode: "zero", historyContext: "", historyUntilId: null })} className="accent-[#9516C7] w-4 h-4 shrink-0" />
                         <span className="text-sm">Repartir de zéro</span>
                       </label>
-                      <label className="flex items-center gap-2 cursor-pointer">
-                        <input type="radio" name="historyMode" value="manual" checked={config.historyMode === "manual"} onChange={() => setConfig({ ...config, historyMode: "manual", historyUntilId: null })} className="accent-[#9516C7]" />
+                      <label className="flex items-center gap-3 cursor-pointer py-1">
+                        <input type="radio" name="historyMode" value="manual" checked={config.historyMode === "manual"} onChange={() => setConfig({ ...config, historyMode: "manual", historyUntilId: null })} className="accent-[#9516C7] w-4 h-4 shrink-0" />
                         <span className="text-sm">Saisir manuellement</span>
                       </label>
                       {config.historyMode === "manual" && (
@@ -755,16 +755,16 @@ export function SimulationStepper() {
                           placeholder="Décrivez le contexte de vos échanges précédents avec ce prospect..."
                           value={config.historyContext}
                           onChange={(e) => setConfig({ ...config, historyContext: e.target.value })}
-                          rows={3}
-                          className="shadow-soft resize-none placeholder:text-foreground/20 ml-6"
+                          rows={5}
+                          className="shadow-soft resize-none placeholder:text-foreground/20 ml-7 w-[calc(100%-1.75rem)] max-w-full min-h-[8rem]"
                         />
                       )}
-                      <label className={`flex items-center gap-2 ${previousConversations.length === 0 ? "opacity-40 cursor-not-allowed" : "cursor-pointer"}`}>
-                        <input type="radio" name="historyMode" value="previous" checked={config.historyMode === "previous"} disabled={previousConversations.length === 0} onChange={() => setConfig({ ...config, historyMode: "previous", historyContext: "" })} className="accent-[#9516C7]" />
-                        <span className="text-sm">
-                          Reprendre l&apos;historique des appels
+                      <label className={`flex items-start gap-3 py-1 ${previousConversations.length === 0 ? "opacity-40 cursor-not-allowed" : "cursor-pointer"}`}>
+                        <input type="radio" name="historyMode" value="previous" checked={config.historyMode === "previous"} disabled={previousConversations.length === 0} onChange={() => setConfig({ ...config, historyMode: "previous", historyContext: "" })} className="accent-[#9516C7] w-4 h-4 shrink-0 mt-0.5" />
+                        <span className="text-sm flex flex-col gap-0.5">
+                          <span>Reprendre l&apos;historique des appels</span>
                           {previousConversations.length === 0 && (
-                            <span className="text-xs text-muted-foreground ml-2">— Aucun appel précédent pour ce prospect + produit</span>
+                            <span className="text-xs text-muted-foreground">Aucun appel précédent pour ce prospect + produit</span>
                           )}
                         </span>
                       </label>

--- a/lib/types/database.ts
+++ b/lib/types/database.ts
@@ -155,6 +155,9 @@ export type Database = {
           duration_seconds: number;
           max_duration_seconds: number;
           elevenlabs_conversation_id: string | null;
+          summary: string | null;
+          history_context: string | null;
+          history_conversation_ids: string[] | null;
           created_at: string;
           updated_at: string;
         };
@@ -174,6 +177,9 @@ export type Database = {
           duration_seconds?: number;
           max_duration_seconds?: number;
           elevenlabs_conversation_id?: string | null;
+          summary?: string | null;
+          history_context?: string | null;
+          history_conversation_ids?: string[] | null;
           created_at?: string;
           updated_at?: string;
         };
@@ -193,6 +199,9 @@ export type Database = {
           duration_seconds?: number;
           max_duration_seconds?: number;
           elevenlabs_conversation_id?: string | null;
+          summary?: string | null;
+          history_context?: string | null;
+          history_conversation_ids?: string[] | null;
           created_at?: string;
           updated_at?: string;
         };

--- a/mission1_neocell.md
+++ b/mission1_neocell.md
@@ -15,61 +15,38 @@
 
 ---
 
-### 1. Historique inter-conversations (R1→R2)
+### 1. Historique inter-conversations (R1→R2) ✅ IMPLÉMENTÉ
 
-**Objectif :** au lancement d'une simulation, injecter un résumé des conversations précédentes avec le même persona dans le prompt ElevenLabs.
+**Branche :** `historique_conversations`
 
-**Migration Supabase :**
+**Migrations Supabase exécutées :**
 ```sql
 ALTER TABLE conversations ADD COLUMN summary TEXT NULL;
+ALTER TABLE conversations ADD COLUMN history_context TEXT NULL;
+ALTER TABLE conversations ADD COLUMN history_conversation_ids UUID[] NULL;
 ```
 
-**Étape 1 — Générer le résumé post-simulation**
+**3 modes d'historique disponibles dans le wizard (étape 4) :**
+- **Repartir de zéro** — aucun historique injecté dans le prompt (défaut)
+- **Saisir manuellement** — champ texte libre, stocké dans `history_context`
+- **Reprendre l'historique des appels** — dropdown avec sélection "jusqu'à quel appel" (Option B cascade : sélectionner le 3ème appel inclut automatiquement les 1er et 2ème), stocké dans `history_conversation_ids[]`
 
-Fichier : `app/api/simulation/[id]/end/route.ts`
+**Condition d'affichage du sélecteur :** uniquement les conversations avec `summary IS NOT NULL`, même `agent_id` (même prospect) ET même `product_id` (même produit), triées par ordre chronologique ASC.
+- Si l'appel concernait un produit différent → n'apparaît pas (injecter un historique sur un produit différent n'aurait pas de sens)
+- Si l'appel concernait un autre prospect avec le même produit → n'apparaît pas non plus (Jean Verdi ne peut pas se souvenir d'une conversation qu'il n'a pas eue)
 
-Après la génération du feedback existant, ajouter un second appel IA qui génère un résumé condensé (~200 mots) de l'appel à partir du transcript. Le résumé doit capturer :
-- L'objectif de l'appel et s'il a été atteint
-- Les points clés abordés
-- Le comportement du prospect (objections, réactions)
-- Le résultat final
+**Fichiers modifiés :**
+- `lib/types/database.ts` — 3 nouvelles colonnes dans Row/Insert/Update
+- `components/simulation/simulation-stepper.tsx` — `historyMode`, `historyContext`, `historyUntilId` dans l'interface + `loadPreviousConversations()` chargé quand agent+produit sont sélectionnés + section UI étape 4 + calcul `history_conversation_ids` dans `startSimulation()`
+- `app/api/simulation/[id]/end/route.ts` — génération du résumé post-simulation via Bedrock (second appel IA après le feedback, non-bloquant), stocké dans `conversations.summary`
+- `app/api/simulation/start/route.ts` — injection de l'historique dans le prompt ElevenLabs si `history_conversation_ids` ou `history_context` renseigné
 
-Stocker ce résumé dans `conversations.summary`.
+**Conditions importantes :**
+- Le résumé est généré uniquement à partir de cette implémentation → les conversations passées (852 sans résumé) ne sont **pas** visibles dans le sélecteur tant qu'elles n'ont pas de `summary`
+- Le sélecteur est grisé avec "Aucun appel précédent pour ce produit" si aucune conversation disponible
+- La cohérence est assurée par l'Option B (cascade) : impossible de sélectionner un appel sans inclure ceux qui le précèdent
 
-**Étape 2 — Récupérer l'historique au démarrage**
-
-Fichier : `app/api/simulation/start/route.ts`
-
-Avant de construire le prompt, requêter les conversations précédentes :
-```sql
-SELECT summary, call_type, created_at
-FROM conversations
-WHERE user_id = $userId
-  AND agent_id = $agentId
-  AND summary IS NOT NULL
-  AND id != $currentConversationId
-ORDER BY created_at DESC
-LIMIT 5
-```
-
-Si des résumés existent → les injecter dans le prompt sous forme de bloc "Historique de vos échanges précédents".
-
-Si l'élève a coché "Repartir de zéro" → ne pas injecter l'historique (flag à passer dans le payload de démarrage et stocker dans `conversations`).
-
-**Étape 3 — Option "Repartir de zéro"**
-
-Migration :
-```sql
-ALTER TABLE conversations ADD COLUMN reset_history BOOLEAN DEFAULT FALSE;
-```
-
-Ajouter un toggle dans l'étape 4 du wizard de configuration (contexte & objectif). Valeur envoyée à `simulation/start` et sauvegardée en base.
-
-**Fichiers touchés :**
-- `app/api/simulation/[id]/end/route.ts` — génération du résumé
-- `app/api/simulation/start/route.ts` — récupération + injection historique
-- `components/simulation/setup/` — ajout du toggle "Repartir de zéro"
-- Migration SQL
+**À tester :** faire 2 simulations avec le même agent + même produit, vérifier que la 2ème affiche la 1ère dans le sélecteur et que le résumé est bien injecté dans le prompt ElevenLabs.
 
 ---
 
@@ -266,6 +243,18 @@ Les anciennes données n'ont pas besoin d'être corrigées (les transcripts sont
 | 🟠 4 | Configuration durée d'appel | Moyen | Économie crédits + UX |
 | 🟡 5 | Fix variables ElevenLabs (conversation ID) | Faible | Qualité technique |
 | 🟡 6 | Historique inter-conversations | Élevé | Feature principale |
+
+---
+
+## Remarques
+
+- **localStorage dans le wizard** — l'étape 4 du wizard (secteur, entreprise, contexte personnalisé) est pré-remplie automatiquement avec la dernière config sauvegardée pour chaque agent. C'est le comportement voulu via `loadSavedConfig` / `saveConfig` dans `simulation-stepper.tsx`. Ce comportement est identique en local et en prod — chaque utilisateur a ses propres données stockées dans le `localStorage` de son navigateur.
+
+---
+
+## À demander à Shannen
+
+- **Résumés des conversations existantes** — 852 conversations ont un transcript mais pas de résumé (feature inexistante avant cette mission). Le sélecteur "Reprendre l'historique" ne les affiche donc pas. On peut générer les résumés manquants via Bedrock en batch, mais c'est coûteux (852 appels IA). À valider avec Shannen : est-ce qu'on génère les résumés rétroactivement, et si oui pour tous les users ou seulement certains ?
 
 ---
 

--- a/mission1_neocell.md
+++ b/mission1_neocell.md
@@ -46,7 +46,13 @@ ALTER TABLE conversations ADD COLUMN history_conversation_ids UUID[] NULL;
 - Le sélecteur est grisé avec "Aucun appel précédent pour ce produit" si aucune conversation disponible
 - La cohérence est assurée par l'Option B (cascade) : impossible de sélectionner un appel sans inclure ceux qui le précèdent
 
-**À tester :** faire 2 simulations avec le même agent + même produit, vérifier que la 2ème affiche la 1ère dans le sélecteur et que le résumé est bien injecté dans le prompt ElevenLabs.
+**À tester (test humain obligatoire) :**
+- Faire 2 simulations avec le même agent + même produit
+- Vérifier que la 2ème simulation affiche la 1ère dans le sélecteur "Reprendre l'historique des appels"
+- Vérifier que le résumé est bien injecté dans le prompt ElevenLabs au démarrage
+- Vérifier que le mode "Saisir manuellement" injecte bien le texte saisi dans le prompt
+- Vérifier que le mode "Repartir de zéro" n'injecte aucun historique
+- Vérifier que si agent ou produit différent, les conversations précédentes n'apparaissent pas dans le sélecteur
 
 ---
 


### PR DESCRIPTION
- Nouveau champ "Historique de la relation" dans le wizard (étape 4), positionné avant la durée d'appel
- 4 options : Premier contact, 2ème appel, 3ème appel+, Relance après silence
- Si l'option est autre que "Premier contact" : affichage conditionnel d'un champ texte libre pour décrire le contexte des échanges précédents
- Ce contexte est injecté dans le prompt ElevenLabs pour que le prospect joue le rôle avec la mémoire de la relation
- Ajustements UI : padding, hauteur textarea, cohérence visuelle avec le reste du wizard