### PR TITLE
fix(feedback): use claude-3-7-sonnet instead of 3-5-haiku

### DIFF
--- a/app/api/simulation/[id]/end/route.ts
+++ b/app/api/simulation/[id]/end/route.ts
@@ -191,7 +191,7 @@ Fournissez un feedback structuré avec:
     try {
       console.log("📡 Sending request to Anthropic...");
       const response = await anthropic.messages.create({
-        model: "claude-3-5-haiku-20241022",
+        model: "claude-3-7-sonnet-20250219",
         max_tokens: 2000,
         temperature: 0.1,
         messages: [{ role: "user", content: feedbackPrompt }],
@@ -326,7 +326,7 @@ Génère un résumé factuel en 3-5 phrases maximum (150 mots max) qui capture :
 Ce résumé sera utilisé pour contextualiser les prochains appels avec ce prospect. Réponds uniquement avec le résumé, sans introduction ni titre.`;
 
         const summaryResponse = await anthropic.messages.create({
-          model: "claude-3-5-haiku-20241022",
+          model: "claude-3-7-sonnet-20250219",
           max_tokens: 300,
           temperature: 0.1,
           messages: [{ role: "user", content: summaryPrompt }],


### PR DESCRIPTION
Le modèle claude-3-5-haiku-20241022 retournait une 404 (non accessible à l'org), ce qui déclenchait systématiquement le fallback feedback. Switch vers claude-3-7-sonnet-20250219 pour feedback + summary.