### PR TITLE
fix(feedback): escape raw control chars in Claude JSON response

### DIFF
--- a/app/api/simulation/[id]/end/route.ts
+++ b/app/api/simulation/[id]/end/route.ts
@@ -231,7 +231,37 @@ Fournissez un feedback structuré avec:
           cleanedText.substring(0, 200) + "..."
         );
 
-        feedbackData = JSON.parse(cleanedText);
+        // Escape raw control characters (Claude sometimes emits real newlines
+        // inside string values, which breaks JSON.parse).
+        // Walk the string, tracking whether we're inside a quoted string,
+        // and escape control chars only inside strings.
+        let sanitized = "";
+        let inString = false;
+        let escapeNext = false;
+        for (const ch of cleanedText) {
+          if (escapeNext) {
+            sanitized += ch;
+            escapeNext = false;
+            continue;
+          }
+          if (ch === "\\" && inString) {
+            sanitized += ch;
+            escapeNext = true;
+            continue;
+          }
+          if (ch === '"') {
+            inString = !inString;
+            sanitized += ch;
+            continue;
+          }
+          if (inString && (ch === "\n" || ch === "\r" || ch === "\t")) {
+            sanitized += ch === "\n" ? "\\n" : ch === "\r" ? "\\r" : "\\t";
+            continue;
+          }
+          sanitized += ch;
+        }
+
+        feedbackData = JSON.parse(sanitized);
         console.log("✅ Successfully parsed Claude JSON feedback:", {
           note: feedbackData.note,
           pointsForts: feedbackData.points_forts?.length,


### PR DESCRIPTION
Claude emits real newlines inside string values (analyse_complete), breaking JSON.parse with 'Bad control character in string literal'. Walk the string and escape \n \r \t only inside quoted values.