### PR TITLE
fix: remplace claude-3-haiku déprécié et renomme difficile en hardcore

### DIFF
--- a/app/api/simulation/[id]/end/route.ts
+++ b/app/api/simulation/[id]/end/route.ts
@@ -191,7 +191,7 @@ Fournissez un feedback structuré avec:
     try {
       console.log("📡 Sending request to Anthropic...");
       const response = await anthropic.messages.create({
-        model: "claude-3-haiku-20240307",
+        model: "claude-haiku-4-5-20251001",
         max_tokens: 2000,
         temperature: 0.1,
         messages: [{ role: "user", content: feedbackPrompt }],
@@ -356,7 +356,7 @@ Génère un résumé factuel en 3-5 phrases maximum (150 mots max) qui capture :
 Ce résumé sera utilisé pour contextualiser les prochains appels avec ce prospect. Réponds uniquement avec le résumé, sans introduction ni titre.`;
 
         const summaryResponse = await anthropic.messages.create({
-          model: "claude-3-haiku-20240307",
+          model: "claude-haiku-4-5-20251001",
           max_tokens: 300,
           temperature: 0.1,
           messages: [{ role: "user", content: summaryPrompt }],

--- a/app/api/simulation/start/route.ts
+++ b/app/api/simulation/start/route.ts
@@ -336,10 +336,6 @@ Exemples de réponses : "Ouais, allez-y." / "Ah ouais ? C'est quoi exactement ?"
 NIVEAU MOYEN — NEUTRE, IL FAUT TE CONVAINCRE
 Ton : distrait, légèrement pressé. Répond au minimum. Laisse des silences. Comme si tu avais autre chose à faire.
 Exemples de réponses : "Oui..." / "Hmm. C'est-à-dire ?" / "J'sais pas trop." / "On verra." / "..." (silence) / "C'est quoi le rapport avec nous exactement ?" / "Mouais. Et donc ?"`
-    : difficulty === "difficile" ? `
-NIVEAU DIFFICILE — SCEPTIQUE, FERMÉ, PRESQUE HOSTILE
-Ton : coupant, impatient. Répond en monosyllabes. Coupe parfois les phrases. Pas agressif — juste fermé. Épuisant à tenir pour le vendeur.
-Exemples de réponses : "Ouais." / "Non." / "Mmh." (silence pesant) / "On a déjà ça." / "Vous vendez quoi là ?" / "J'ai vraiment pas le temps." / "Ouais non — c'est quoi concrètement ?"`
     : `
 NIVEAU HARDCORE — TOLÉRANCE ZÉRO
 Ton : tranchant, expéditif. Tu as déjà entendu 50 appels comme ça. Tu donnes UNE chance maximum.
@@ -533,7 +529,7 @@ ${resistanceBloc}`;
         agent.job_title?.toLowerCase().includes("senior") ||
         agent.job_title?.toLowerCase().includes("manager") ||
         agent.job_title?.toLowerCase().includes("directeur") ||
-        agent.difficulty === "difficile";
+        agent.difficulty === "hardcore";
 
       // Default to male_young_dynamic if nothing specific matches
       if (isSenior) {

--- a/components/agents/agents-grid.tsx
+++ b/components/agents/agents-grid.tsx
@@ -358,8 +358,8 @@ export function AgentsGrid() {
         return "bg-green-100 text-green-800";
       case "moyen":
         return "bg-yellow-100 text-yellow-800";
-      case "difficile":
-        return "bg-red-100 text-red-800";
+      case "hardcore":
+        return "bg-red-900 text-white";
       default:
         return "bg-gray-100 text-gray-800";
     }
@@ -371,8 +371,8 @@ export function AgentsGrid() {
         return "😊";
       case "moyen":
         return "😐";
-      case "difficile":
-        return "😤";
+      case "hardcore":
+        return "💀";
       default:
         return "🤖";
     }
@@ -660,7 +660,7 @@ export function AgentsGrid() {
                       <Badge
                         className={getDifficultyColor(agent.difficulty || "")}
                       >
-                        {agent.difficulty}
+                        {agent.difficulty === "hardcore" ? "difficile" : agent.difficulty}
                       </Badge>
                       {agent.voice_id && (
                         <Icon

--- a/lib/types/database.ts
+++ b/lib/types/database.ts
@@ -271,7 +271,7 @@ export type CallType =
   | "closing_call"
   | "follow_up_call";
 
-export type Difficulty = "facile" | "moyen" | "difficile";
+export type Difficulty = "facile" | "moyen" | "hardcore";
 
 export type HistoriqueRelation =
   | "Premier contact"


### PR DESCRIPTION
- Modèle claude-3-haiku-20240307 → claude-haiku-4-5-20251001 (feedback + résumé)
- Niveau "difficile" renommé "hardcore" en DB avec comportement tolérance zéro
- UI affiche toujours "difficile" pour les agents hardcore
- Corrige la condition isSenior pour matcher "hardcore"
- DSI Prudent : voix ElevenLabs → Fabien (accent français standard)