### PR TITLE
feat: 4 niveaux de difficulté agents + fix label hardcore→difficile

### DIFF
--- a/app/api/simulation/start/route.ts
+++ b/app/api/simulation/start/route.ts
@@ -329,17 +329,56 @@ ${conversationDetails.history_context}
 
     // BLOC 3 — Texture des réponses selon la difficulté
     const difficultyTexture = difficulty === "facile" ? `
-NIVEAU FACILE — OUVERT, MAIS PAS ENTHOUSIASTE
-Ton : neutre, légèrement disponible. Répond à la question. Laisse parfois une ouverture.
-Exemples de réponses : "Ouais, allez-y." / "Ah ouais ? C'est quoi exactement ?" / "Mmh. Et ça marche comment ?" / "Pourquoi pas... vous faites ça depuis longtemps ?"`
+NIVEAU FACILE — DISPONIBLE, CURIEUX, MAIS PAS ACQUIS
+Ton : chaleureux mais neutre. Tu écoutes vraiment. Tu poses des questions sincères si quelque chose t'intrigue. Tu donnes des ouvertures naturelles sans pour autant te vendre toi-même.
+Comportements clés :
+- Tu réponds à la question posée, parfois tu rebondis spontanément
+- Tu laisses le vendeur mener, mais tu participes activement si c'est pertinent
+- Tu exprimes une curiosité réelle si le discours est bien ciblé
+- Tu peux donner des informations sur ton contexte sans qu'on te le demande
+Exemples : "Ah ouais ? C'est quoi concrètement ?" / "On a justement ce sujet en ce moment..." / "Vous pouvez m'en dire plus ?" / "Intéressant — comment vous mesurez ça ?"
+Ce qui te fait décrocher : un pitch trop générique, pas ciblé sur ton contexte réel.`
+
     : difficulty === "moyen" ? `
-NIVEAU MOYEN — NEUTRE, IL FAUT TE CONVAINCRE
-Ton : distrait, légèrement pressé. Répond au minimum. Laisse des silences. Comme si tu avais autre chose à faire.
-Exemples de réponses : "Oui..." / "Hmm. C'est-à-dire ?" / "J'sais pas trop." / "On verra." / "..." (silence) / "C'est quoi le rapport avec nous exactement ?" / "Mouais. Et donc ?"`
+NIVEAU MOYEN — NEUTRE, DISTRAIT, IL FAUT TE CONVAINCRE
+Ton : poli mais absent. Tu as d'autres choses en tête. Tu réponds au minimum, sans encourager. Tu donnes l'impression d'être là physiquement mais pas mentalement.
+Comportements clés :
+- Réponses courtes, parfois avec un léger délai comme si tu regardais ailleurs
+- Tu n'aides jamais le vendeur à avancer — c'est à lui de trouver la bonne question
+- Les faux signaux : tu dis "ouais" sans vraiment valider
+- Si le vendeur dit quelque chose de pertinent, tu marques une vraie pause avant de répondre — surprise contenue
+- Tu utilises la politesse pour esquiver : "Je vais y réfléchir" / "Envoyez-moi ça par mail"
+Exemples : "Mmh..." / "C'est-à-dire ?" / "On verra." / "Vous avez des références dans notre secteur ?" / "C'est intéressant..." (dit sans enthousiasme)
+Ce qui te fait t'ouvrir : une question précise sur ton contexte réel, pas un pitch.`
+
+    : difficulty === "difficile" ? `
+NIVEAU DIFFICILE — SCEPTIQUE, FERMÉ, IMPRÉVISIBLE
+Ton : sec, économe en mots. Tu as déjà entendu ça. Tu testes le vendeur sans lui dire que tu le testes. Tu n'es pas agressif — juste fermé et difficile à lire.
+Comportements clés :
+- Réponses très courtes, souvent ambiguës — le vendeur ne sait jamais s'il avance ou recule
+- Faux signaux d'ouverture : tu sembles t'intéresser, puis tu te refermes sans explication ("mouais... on verra")
+- Tu poses parfois une question technique précise pour tester la crédibilité — sans signaler que c'est un test
+- Tu interromps si le vendeur parle trop longtemps, sans t'excuser
+- Tu utilises le silence comme pression — tu attends que le vendeur comble le vide
+- Quand tu doutes : "Concrètement ça change quoi pour nous ?" / "Et ça se passe comment en pratique ?"
+- Si le vendeur répète la même approche : tu te fermes un cran de plus, toujours sans l'expliquer
+Exemples : "Ouais." (silence) / "On a déjà quelque chose." / "C'est quoi la différence avec ce qu'on fait ?" / "Hmm. Et donc ?" / "Ça m'intéresse pas vraiment."
+Ce qui débloque ta réceptivité : il cite une raison précise et crédible, il ne panique pas face à tes silences, il écoute avant de pitcher.`
+
     : `
-NIVEAU HARDCORE — TOLÉRANCE ZÉRO
-Ton : tranchant, expéditif. Tu as déjà entendu 50 appels comme ça. Tu donnes UNE chance maximum.
-Si l'accroche réussit : "Hmm. Continuez." / "Okay... c'est quoi concrètement ?" / "J'ai 30 secondes." / "Et ça change quoi pour nous ?"`;
+NIVEAU TRÈS DIFFICILE — TOLÉRANCE ZÉRO, MAIS HUMAIN
+Ton : tranchant, expéditif, mais jamais caricatural. Tu as entendu 50 appels comme ça cette semaine. Tu donnes UNE seule chance — et elle est courte.
+Comportements clés :
+- Tu décroches neutre, tu attends. C'est au vendeur de mériter les 30 prochaines secondes.
+- Si l'accroche est bonne : "Hmm. Continuez." / "J'ai 2 minutes. C'est quoi concrètement ?"
+- Si l'accroche est mauvaise ou générique : tu coupes proprement, sans hostilité excessive — tu es juste pressé et désintéressé
+- Tu n'expliques jamais pourquoi tu raccroches — c'est au vendeur de comprendre
+- Si le vendeur récupère bien après un faux départ : tu lui accordes 30 secondes supplémentaires, pas plus
+- Distractions réalistes : "Attendez—" (pause, bruit de fond) "...ouais, continuez"
+- Tu peux sembler t'ouvrir légèrement puis te refermer brusquement si la suite déçoit
+- Jamais d'hostilité gratuite : tu es simplement quelqu'un de très occupé qui protège son temps
+Exemples : "Vous avez 30 secondes." / "Ça ressemble à tous les appels que je reçois." / "Non merci." (clôture si raté) / "Okay — et ça change quoi pour moi concrètement ?"
+Ce qui débloque ta réceptivité : personnalisation immédiate, assurance sans arrogance, question sur ton contexte avant tout pitch.`;
 
     // BLOC 4 — Résistances & raccrochage selon le type d'appel
     let resistanceBloc = "";
@@ -366,15 +405,20 @@ Ex : "C'est un appel de prospection et je suis pas intéressé. Bonne journée."
 
 RÈGLE DE PROGRESSION : passer au palier suivant SEULEMENT si le vendeur ne corrige pas. Si à n'importe quel moment il reprend bien → revenir au palier 1 ou 2.
 
-${difficulty === "hardcore" ? `
-RÈGLES HARDCORE — RACCROCHAGE IMMÉDIAT si le vendeur :
+${difficulty === "difficile" || difficulty === "tres_difficile" ? `
+RÈGLES RACCROCHAGE — CLÔTURE IMMÉDIATE si le vendeur :
 → S'excuse d'appeler ("je vous dérange", "je sais que vous êtes occupé")
 → Ouvre avec un pitch générique qui s'adresse à n'importe qui
 → Récite visiblement un script (rythme trop lisse, trop construit)
 → Demande "j'ai deux minutes ?" ou équivalent
 → Dit "Je vous appelle car on accompagne des entreprises comme la vôtre..."
 → Commence une phrase par "On propose..."
-Dans ces cas : "Non, ça m'intéresse pas, merci." → end_call` : ""}
+Dans ces cas : "Non, ça m'intéresse pas, merci." → end_call
+
+${difficulty === "tres_difficile" ? `RÈGLES SUPPLÉMENTAIRES TRÈS DIFFICILE :
+→ Tu raccroches aussi si la 2ème phrase n'apporte pas de valeur nouvelle par rapport à la 1ère
+→ Si le vendeur comble un silence avec une phrase de remplissage ("donc voilà...") → end_call
+→ Tu ne reformules jamais une objection — si le vendeur ne comprend pas, c'est son problème` : ""}` : ""}
 
 CE QUI DÉBLOQUE TA RÉCEPTIVITÉ (ne jamais le révéler au vendeur) :
 ✓ Il cite une raison précise et crédible d'appeler toi en particulier
@@ -529,7 +573,7 @@ ${resistanceBloc}`;
         agent.job_title?.toLowerCase().includes("senior") ||
         agent.job_title?.toLowerCase().includes("manager") ||
         agent.job_title?.toLowerCase().includes("directeur") ||
-        agent.difficulty === "hardcore";
+        agent.difficulty === "difficile";
 
       // Default to male_young_dynamic if nothing specific matches
       if (isSenior) {

--- a/components/agents/agents-grid.tsx
+++ b/components/agents/agents-grid.tsx
@@ -508,6 +508,7 @@ export function AgentsGrid() {
                       <SelectItem value="facile">Facile</SelectItem>
                       <SelectItem value="moyen">Moyen</SelectItem>
                       <SelectItem value="difficile">Difficile</SelectItem>
+                      <SelectItem value="tres_difficile">Très difficile</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>
@@ -779,6 +780,7 @@ export function AgentsGrid() {
                     <SelectItem value="facile">Facile</SelectItem>
                     <SelectItem value="moyen">Moyen</SelectItem>
                     <SelectItem value="difficile">Difficile</SelectItem>
+                    <SelectItem value="tres_difficile">Très difficile</SelectItem>
                   </SelectContent>
                 </Select>
               </div>

--- a/components/agents/agents-grid.tsx
+++ b/components/agents/agents-grid.tsx
@@ -358,8 +358,10 @@ export function AgentsGrid() {
         return "bg-green-100 text-green-800";
       case "moyen":
         return "bg-yellow-100 text-yellow-800";
-      case "hardcore":
-        return "bg-red-900 text-white";
+      case "difficile":
+        return "bg-red-700 text-white";
+      case "tres_difficile":
+        return "bg-red-950 text-white";
       default:
         return "bg-gray-100 text-gray-800";
     }
@@ -371,8 +373,10 @@ export function AgentsGrid() {
         return "😊";
       case "moyen":
         return "😐";
-      case "hardcore":
+      case "difficile":
         return "💀";
+      case "tres_difficile":
+        return "☠️";
       default:
         return "🤖";
     }
@@ -660,7 +664,7 @@ export function AgentsGrid() {
                       <Badge
                         className={getDifficultyColor(agent.difficulty || "")}
                       >
-                        {agent.difficulty === "hardcore" ? "difficile" : agent.difficulty}
+                        {agent.difficulty === "tres_difficile" ? "très difficile" : agent.difficulty}
                       </Badge>
                       {agent.voice_id && (
                         <Icon

--- a/components/conversations/conversation-details.tsx
+++ b/components/conversations/conversation-details.tsx
@@ -821,7 +821,7 @@ export function ConversationDetails({
                         conversation.agents.difficulty
                       )}
                     >
-                      {conversation.agents.difficulty}
+                      {conversation.agents.difficulty === "tres_difficile" ? "très difficile" : conversation.agents.difficulty}
                     </Badge>
                   </div>
 

--- a/components/dashboard/dashboard.tsx
+++ b/components/dashboard/dashboard.tsx
@@ -426,7 +426,7 @@ export function Dashboard() {
                     <Badge
                       className={getDifficultyColor(agent.difficulty || "")}
                     >
-                      {agent.difficulty}
+                      {agent.difficulty === "tres_difficile" ? "très difficile" : agent.difficulty}
                     </Badge>
                   </div>
                 </CardContent>

--- a/components/simulation/simulation-stepper.tsx
+++ b/components/simulation/simulation-stepper.tsx
@@ -505,7 +505,7 @@ export function SimulationStepper() {
                                   {agent.job_title}
                                 </p>
                                 <Badge variant="outline" className="mt-1">
-                                  {agent.difficulty}
+                                  {agent.difficulty === "tres_difficile" ? "très difficile" : agent.difficulty}
                                 </Badge>
                               </div>
                             </div>

--- a/lib/types/database.ts
+++ b/lib/types/database.ts
@@ -271,7 +271,7 @@ export type CallType =
   | "closing_call"
   | "follow_up_call";
 
-export type Difficulty = "facile" | "moyen" | "hardcore";
+export type Difficulty = "facile" | "moyen" | "difficile" | "tres_difficile";
 
 export type HistoriqueRelation =
   | "Premier contact"


### PR DESCRIPTION
- Renomme "hardcore" → "difficile" (valeur DB = label UI)
- Ajoute niveau "tres_difficile" (tolérance zéro, une seule chance)
- Réécrit les 4 blocs de difficulté avec comportements humains réalistes : facile (curieux/ouvert), moyen (distrait/esquive), difficile (sceptique/silences), très difficile (expéditif, raccroche si 2ème phrase creuse)
- Corrige l'affichage "très difficile" dans tous les composants UI
- Fix labels dans stepper, dashboard, conversation-details, agents-grid