### PR TITLE
feat(simulation): passe la limite de 3/jour à 90/mois (reset le 1er)

### DIFF
--- a/app/api/simulation/start/route.ts
+++ b/app/api/simulation/start/route.ts
@@ -34,20 +34,20 @@ export async function POST(request: NextRequest) {
 
     console.log("✅ User authenticated:", user.id);
 
-    // Check daily simulation limit (exclure la conversation courante car créée avant /start)
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    const { count: dailyCount } = await supabase
+    // Check monthly simulation limit (exclure la conversation courante car créée avant /start)
+    const now = new Date();
+    const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+    const { count: monthlyCount } = await supabase
       .from("conversations")
       .select("id", { count: "exact", head: true })
       .eq("user_id", user.id)
       .neq("id", conversation_id)
-      .gte("created_at", today.toISOString());
+      .gte("created_at", monthStart.toISOString());
 
-    if ((dailyCount ?? 0) >= 3) {
-      console.warn("⚠️ Daily simulation limit reached for user:", user.id);
+    if ((monthlyCount ?? 0) >= 90) {
+      console.warn("⚠️ Monthly simulation limit reached for user:", user.id);
       return NextResponse.json(
-        { error: "Limite de 3 simulations par jour atteinte. Revenez demain !" },
+        { error: "Limite de 90 simulations par mois atteinte. Réinitialisation le 1er du mois prochain." },
         { status: 429 }
       );
     }

--- a/components/dashboard/dashboard.tsx
+++ b/components/dashboard/dashboard.tsx
@@ -26,7 +26,7 @@ export function Dashboard() {
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [agents, setAgents] = useState<Agent[]>([]);
   const [products, setProducts] = useState<Product[]>([]);
-  const [dailyCount, setDailyCount] = useState(0);
+  const [monthlyCount, setMonthlyCount] = useState(0);
   const [loading, setLoading] = useState(true);
 
   const supabase = createClient();
@@ -40,10 +40,10 @@ export function Dashboard() {
         } = await supabase.auth.getUser();
 
         if (user) {
-          const today = new Date();
-          today.setHours(0, 0, 0, 0);
+          const now = new Date();
+          const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
 
-          const [conversationsResponse, agentsResponse, productsResponse, dailyResponse] = await Promise.all([
+          const [conversationsResponse, agentsResponse, productsResponse, monthlyResponse] = await Promise.all([
             supabase
               .from("conversations")
               .select(`*, agents:agent_id (name, job_title, picture_url, firstname, lastname), feedback:feedback_id (note)`)
@@ -56,13 +56,13 @@ export function Dashboard() {
               .from("conversations")
               .select("id", { count: "exact", head: true })
               .eq("user_id", user.id)
-              .gte("created_at", today.toISOString()),
+              .gte("created_at", monthStart.toISOString()),
           ]);
 
           setConversations(conversationsResponse.data || []);
           setAgents(agentsResponse.data || []);
           setProducts(productsResponse.data || []);
-          setDailyCount(dailyResponse.count ?? 0);
+          setMonthlyCount(monthlyResponse.count ?? 0);
         }
       } catch (error) {
         console.error("Error loading dashboard data:", error);
@@ -256,18 +256,14 @@ export function Dashboard() {
             )}
             </div>
             <div className="flex items-center gap-2 px-3 py-1.5 rounded-full border border-purple-200 bg-purple-50">
-              <div className="flex gap-0.5">
-                {[0, 1, 2].map((i) => (
-                  <div
-                    key={i}
-                    className={`w-2 h-2 rounded-full transition-all duration-300 ${
-                      i < dailyCount ? "bg-[#9516C7]" : "bg-purple-200"
-                    }`}
-                  />
-                ))}
+              <div className="h-1.5 w-16 bg-purple-200 rounded-full overflow-hidden">
+                <div
+                  className="h-full bg-[#9516C7] rounded-full transition-all duration-300"
+                  style={{ width: `${Math.min((monthlyCount / 90) * 100, 100)}%` }}
+                />
               </div>
-              <span className={`text-xs font-semibold ${dailyCount >= 3 ? "text-red-600" : "text-[#9516C7]"}`}>
-                {dailyCount >= 3 ? "Limite atteinte" : `${dailyCount}/3 aujourd'hui`}
+              <span className={`text-xs font-semibold ${monthlyCount >= 90 ? "text-red-600" : "text-[#9516C7]"}`}>
+                {monthlyCount >= 90 ? "Limite atteinte" : `${monthlyCount}/90 ce mois-ci`}
               </span>
             </div>
           </div>

--- a/components/layout/app-sidebar.tsx
+++ b/components/layout/app-sidebar.tsx
@@ -63,7 +63,7 @@ const items = [
 
 export function AppSidebar() {
   const [conversations, setConversations] = useState<any[]>([]);
-  const [dailyCount, setDailyCount] = useState(0);
+  const [monthlyCount, setMonthlyCount] = useState(0);
   const [loading, setLoading] = useState(true);
   const [userProfile, setUserProfile] = useState<any>(null);
   const router = useRouter();
@@ -101,10 +101,10 @@ export function AppSidebar() {
       } = await supabase.auth.getUser();
 
       if (user) {
-        const today = new Date();
-        today.setHours(0, 0, 0, 0);
+        const now = new Date();
+        const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
 
-        const [conversationsResponse, dailyResponse, profileResponse] = await Promise.all([
+        const [conversationsResponse, monthlyResponse, profileResponse] = await Promise.all([
           supabase
             .from("conversations")
             .select(`*, agents:agent_id (name, job_title), feedback:feedback_id (note)`)
@@ -115,7 +115,7 @@ export function AppSidebar() {
             .from("conversations")
             .select("id", { count: "exact", head: true })
             .eq("user_id", user.id)
-            .gte("created_at", today.toISOString()),
+            .gte("created_at", monthStart.toISOString()),
           supabase
             .from("users")
             .select("firstname, lastname, picture_url, email, is_admin")
@@ -124,7 +124,7 @@ export function AppSidebar() {
         ]);
 
         setConversations(conversationsResponse.data || []);
-        setDailyCount(dailyResponse.count ?? 0);
+        setMonthlyCount(monthlyResponse.count ?? 0);
         setUserProfile(profileResponse.data);
       }
     } catch (error) {
@@ -199,7 +199,7 @@ export function AppSidebar() {
           </SidebarGroupLabel>
           <SidebarGroupContent className="pt-4">
             <div className="mb-4">
-              {dailyCount >= 3 ? (
+              {monthlyCount >= 90 ? (
                 <div className="flex flex-col items-center gap-3">
                   <Button
                     className="w-full shannen-gradient font-bold py-5 border-purple-200/50 text-white opacity-50 cursor-not-allowed"
@@ -209,7 +209,7 @@ export function AppSidebar() {
                     Démarrer !
                   </Button>
                   <p className="text-xs text-red-500 font-medium text-center">
-                    Limite atteinte · Revenez demain
+                    Limite atteinte · Réinitialisation le 1er
                   </p>
                 </div>
               ) : (
@@ -222,13 +222,13 @@ export function AppSidebar() {
                   </Link>
                   <div className="w-full">
                     <div className="flex justify-between items-center mb-1">
-                      <span className="text-xs text-muted-foreground">Simulations aujourd&apos;hui</span>
-                      <span className="text-xs font-semibold text-[#9516C7]">{dailyCount}/3</span>
+                      <span className="text-xs text-muted-foreground">Simulations ce mois-ci</span>
+                      <span className="text-xs font-semibold text-[#9516C7]">{monthlyCount}/90</span>
                     </div>
                     <div className="h-1 w-full bg-purple-100 rounded-full overflow-hidden">
                       <div
                         className="h-full bg-[#9516C7] rounded-full transition-all duration-300"
-                        style={{ width: `${(dailyCount / 3) * 100}%` }}
+                        style={{ width: `${(monthlyCount / 90) * 100}%` }}
                       />
                     </div>
                   </div>


### PR DESCRIPTION
Feedback des élèves de Shannen : certains se connectent par sessions longues plutôt que tous les jours. Une limite mensuelle est plus adaptée qu'une limite quotidienne.

- /api/simulation/start : fenêtre de comptage = début du mois courant, seuil 90
- Sidebar : "Simulations ce mois-ci · N/90", message "Réinitialisation le 1er"
- Dashboard : badge remplacé par mini progress bar (3 dots ne tiennent plus à 90)